### PR TITLE
Adjust 'login' menu position & navbar height set

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -11,7 +11,7 @@
             <img :src="account.picture || user.picture" alt="account photo" height="40" class="rounded" />
           </div>
         </div>
-        <div class="dropdown-menu dropdown-menu-lg-end dropdown-menu-start p-0" aria-labelledby="authDropdown">
+        <div class="dropdown-menu dropdown-menu-sm-end dropdown-menu-start p-0" aria-labelledby="authDropdown">
           <div class="list-group">
             <router-link :to="{ name: 'Account' }">
               <div class="list-group-item dropdown-item list-group-item-action">

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -19,7 +19,9 @@
       </ul>
       <!-- LOGIN COMPONENT HERE -->
       <div>
-        <button class="btn text-light" @click="toggleTheme"><i class="mdi" :class="theme == 'light' ? 'mdi-weather-sunny' : 'mdi-weather-night'"></i></button>
+        <button class="btn text-light" @click="toggleTheme">
+          <i class="mdi" :class="theme == 'light' ? 'mdi-weather-sunny' : 'mdi-weather-night'"></i>
+        </button>
       </div>
       <Login />
     </div>
@@ -67,7 +69,7 @@ a:hover {
   border-bottom-right-radius: 0;
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 576px) {
   nav {
     height: 64px;
   }


### PR DESCRIPTION
Adjusted the 'login' menu position & navbar height setting (at the navbar media query) to match with navbar menu collapse/expand at bootstrap's 'sm' breakpoint